### PR TITLE
Basic functionality to sync from publications.scilifelab.se

### DIFF
--- a/_sync_db.php
+++ b/_sync_db.php
@@ -1,0 +1,39 @@
+<?php
+require 'lib/global.php';
+
+if($USER->auth>0) {
+	$pubmed=new PHPMed();
+	$publications=new NGIpublications();
+	//----------------------------------------------------
+	// "Sync" with SciLifeLab Publications database
+
+
+	// JSON sources for Production and Applications papers in the SciLifeLab database
+	$sources=array(
+		'https://publications.scilifelab.se/label/NGI%20Stockholm%20%28Genomics%20Production%29.json',
+		'https://publications.scilifelab.se/label/NGI%20Stockholm%20%28Genomics%20Applications%29.json'
+	);
+	$list=$publications->checkDB($sources);
+
+	// Auto add missing papers
+	/* $autoadd_data=$pubmed->summary($list['missing']);
+
+	// OBS! This will NOT parse authors since no lab is given, however this will be done if the PMID shows up in searches
+	// Not a big issue since this is likely only a one-time event and only for old papers
+	$add_papers=$publications->addBatch($autoadd_data,FALSE);
+	*/
+	$errors[]='None';
+
+} else {
+	// Not logged in
+	$errors[]='Not logged in';
+}
+
+echo json_encode(array('verified_and_added' => count($list['verified_and_added']),
+					   'missing' => count($list['missing']),
+					   'mismatch' => $list['mismatch'],
+					   'auto' => count($list['auto']),
+					   'no_change' => count($list['no_change']),
+					   'other_unknown_status' => $list['other_unkown_status'],
+					   'total' => count($list['total']),
+					   'errors' => implode(', ', $errors)));

--- a/js/app.js
+++ b/js/app.js
@@ -105,7 +105,51 @@ $(document).ready(function() {
 	$('.pause_trawl').on('click', function() {
 		
 	});
-	
+
+	$('.start_sync').on('click', function() {
+		$.ajax({
+			url: '_sync_db.php',
+			beforeSend: function() {
+				$("#sync_status_message").append(
+					'<div class="callout primary", id="syncing_ongoing">(imagine a rolling circle) Syncing database against publications.scilifelab.se</div>'
+				);
+			},
+			success: function(json_str) {
+				json = JSON.parse(json_str);
+				$("#syncing_ongoing").remove();
+				if (json["mismatch"] != null && json["mismatch"].length > 0){
+					$("#sync_status_message").append(
+						'<div class="callout alert"> Warning: These publications from publications.scilifelab.se are marked as "maybe" or "discarded": ' + json["mismatch"] + '</br> - Consider to remove these from publications.scilifelab.se </div>'
+					);
+				};
+				if (json["other_unknown_status"] != null && json["other_unknown_status"].length > 0) {
+					$("#sync_status_message").append(
+						'<div class="callout alert"> Warning: These publications from publications.scilifelab.se have unknown statuses in the local database: ' + json["other_unknown_status"] + '</div>'
+					);
+				};
+				if (json["missing"] != null && json["missing"].length > 0) {
+					$("#sync_status_message").append(
+						'<div class="callout alert"> Warning: These publications from publications.scilifelab.se are missing in the local database: ' + json["missing"] + '</div>'
+					);
+				};
+				$("#sync_status_message").append(
+					'<div class="callout success"><ul>' +
+						'<li>' + json['total'] + ' papers fetched in total</li>' +
+						'<li>' + json['verified_and_added'] + ' papers were verified and also added.</li>' +
+						'<li>' + json['auto'] + ' papers were added but not verified (auto)</li>' +
+						'<li>' + json['no_change'] + ' papers were already noted as auto or added in database</li></ul>' +
+					'</div>'
+				);
+			},
+			error: function(xhr, error){
+        		console.debug(xhr); console.debug(error);
+				$("#sync_status_message").append(
+					'<div class="callout alert">ERROR: Syncing database failed!</div>'
+				);
+ 			}
+		})
+	});
+
 	$('.verify_button').on('click', function() {
 		var button = this;
 		var id = $(this).attr('id').split('-')[1];

--- a/lib/class.NGIpublications.php
+++ b/lib/class.NGIpublications.php
@@ -88,14 +88,14 @@ class NGIpublications {
 	public function checkDB($sources) {
 		if(is_array($sources)) {
 			$now=date('Y-m-d');
-			
+
 			// Fetch data from SciLifeLab publication database
 			foreach($sources as $source) {
 				$data[]=json_decode(file_get_contents($source),TRUE);
 			}
-			
-			// Consolidate lists (pub db has two labels for NGI Stockholm, see above)
-			// Use PMID and/or DOI as key to get rid of duplicates 
+
+			// Consolidate lists (pub db has two labels for NGI Stockholm, see _sync_db
+			// Use PMID and/or DOI as key to get rid of duplicates
 			foreach($data as $set) {
 				foreach($set['publications'] as $publication) {
 					if($publication['pmid']>0) {
@@ -115,22 +115,33 @@ class NGIpublications {
 					$local['doi'][$paper['doi']]=$paper['status'];
 				}
 			}
-				
+
 			// Check which PMID's exist in local db
 			foreach($remote['pmid'] as $pmid) {
+				$list['total'][] = $pmid;
 				//if($check=sql_fetch("SELECT pmid FROM publications WHERE pmid=$pmid")) {
 				if(array_key_exists($pmid, $local['pmid'])) {
 					// Paper already exist in local db
 					if($local['pmid'][$pmid]!='') {
-						// Status already set, DO NOT CHANGE!
-						// Report if matches with "discarded" or "maybe"
-						if($local['pmid'][$pmid]=='discarded' || $local['pmid'][$pmid]=='maybe') {
+						// Status already set
+						// If verified, note that it is also added
+						if ($local['pmid'][$pmid]=='verified') {
+							$update=sql_query("UPDATE publications SET status='verified_and_added' WHERE pmid=$pmid");
+							$list['verified_and_added'][]=$pmid;
+						} elseif ($local['pmid'][$pmid]=='discarded' || $local['pmid'][$pmid]=='maybe') {
+							// Report if matches with "discarded" or "maybe"
 							$list['mismatch'][]=$pmid;
+						} elseif ($local['pmid'][$pmid]=='auto' || $local['pmid'][$pmid]=='verified_and_added') {
+							$list['no_change'][]=$pmid;
+						} else {
+							$list['other_unknown_status'][] = $pmid;
 						}
 					} else {
-						// Status not set, set status to "auto". 
+						// This should be a quite rare case
+						// Status not set, set status to "auto".
 						// Use "auto" since it might be good to double check these, there has been some erroneously added papers in the past
 						$update=sql_query("UPDATE publications SET status='auto',submitted='$now' WHERE pmid=$pmid");
+						$list['auto'][]=$pmid;
 					}
 				} else {
 					// Paper does not exist in local db

--- a/sync_db.php
+++ b/sync_db.php
@@ -1,0 +1,49 @@
+<?php
+require 'lib/global.php';
+$pubmed=new PHPMed();
+$researchers=new NGIresearchers();
+$publications=new NGIpublications();
+
+if($USER->auth>0) {
+
+} else {
+	// Not logged in
+	header('Location:login.php');
+}
+
+
+// Render Page
+//=================================================================================================
+?>
+
+<!doctype html>
+<html class="no-js" lang="en" dir="ltr">
+
+<head>
+	<meta charset="utf-8">
+	<meta http-equiv="x-ua-compatible" content="ie=edge">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<title><?php echo $CONFIG['site']['name']; ?></title>
+	<link rel="stylesheet" href="css/foundation.css">
+	<link rel="stylesheet" href="css/app.css">
+	<link rel="stylesheet" href="css/icons/foundation-icons.css" />
+</head>
+
+<body>
+<?php require '_menu.php'; ?>
+
+<div class="row">
+	<br>
+	<div class="large-12 columns">
+		<span class="start_sync button">Begin syncing from publications.scilifelab.se</span>
+	</div>
+	<div class="card-section large-6 columns" id="sync_status_message"></div>
+</div>
+
+<script src="js/vendor/jquery.js"></script>
+<script src="js/vendor/what-input.js"></script>
+<script src="js/vendor/foundation.js"></script>
+<script src="js/app.js"></script>
+</body>
+
+</html>


### PR DESCRIPTION
Very basic, but still functional, implementation of syncing from publications.scilifelab.se.

Potential problems:
- No specific field for `Added`, this is only saved to db if the paper is also `verified` (changing the status to `verified_and_added` in that case).
- If the status is `maybe` or `discarded` but the paper was still fetched from upstream, it would not be noted in the database.
- The url is still hidden (`/sync_db.php`)
- I fear I put a bit too much html into the javascript function. 
- The css might have some slight alignment problems :wink::

<img width="1230" alt="screen shot 2018-10-02 at 11 21 34" src="https://user-images.githubusercontent.com/1250075/46340329-6a130d80-c635-11e8-97b9-6774ca4d78a0.png">
