### PR TITLE
Use 8 instead of 5 as minimum score

### DIFF
--- a/publications_verify.php
+++ b/publications_verify.php
@@ -7,7 +7,7 @@ if($USER->auth>0) {
 		$page=1;
 	}
 
-	$query=$publications->reservePublications($USER->data['user_email'],date('Y'),5);
+	$query=$publications->reservePublications($USER->data['user_email'],date('Y'),8);
 	$publication_list=$publications->showPublicationList($query,$page);
 } else {
 	// Not logged in


### PR DESCRIPTION
Using the scores of the publications already added to the database, I would argue that a score of 8 is a suitable cutoff. This corresponds to the 5% quantile which would reduce the number of publications in need of review with ~ 30% more.

Data:
Approved quantiles: 8.00 - 5%, 9.70 - 10%
For pending (out of 6462 total), 2874 are above 5, 1930 are above 8.00 and 1888 are above 9.70